### PR TITLE
[FIX] l10n_es_igic: fix module category incl. cleaning

### DIFF
--- a/l10n_es_igic/__manifest__.py
+++ b/l10n_es_igic/__manifest__.py
@@ -7,13 +7,13 @@
 
 {
     "name": "IGIC (Impuesto General Indirecto Canario",
-    "version": "13.0.1.0.0",
+    "version": "13.0.1.0.1",
     "author": "David Diz Martínez,"
     "Atlantux Consultores - Enrique Zanardi,"
     "Sistemas de Datos,"
     "Comunitea,"
     "Odoo Community Association (OCA)",
-    "category": "Accounting/Localizations/Account Charts",
+    "category": "Localization",
     "website": "https://github.com/OCA/l10n-spain",
     "depends": ["l10n_es"],
     "license": "AGPL-3",

--- a/l10n_es_igic/migrations/13.0.1.0.1/post-migration.py
+++ b/l10n_es_igic/migrations/13.0.1.0.1/post-migration.py
@@ -1,0 +1,20 @@
+from odoo import SUPERUSER_ID, api
+
+
+def migrate(cr, version):
+    """Reassign the conventional module category for localizations in Odoo 13.
+
+    The previously assigned categories from Odoo 16 break the Odoo migration process.
+
+    ```
+    odoo.upgrade.util.exceptions.MigrationError:
+    Can't rename base.module_category_localization_account_charts to
+    base.module_category_accounting_localizations_account_charts as it already exists.
+    ```
+    """
+    with api.Environment.manage():
+        env = api.Environment(cr, SUPERUSER_ID, {})
+        module = env["ir.module.module"].search([("name", "=", "l10n_es_igic")])
+        module.category_id = env.ref("base.module_category_localization")
+        env.ref("base.module_category_accounting_localizations_account_charts").unlink()
+        env.ref("base.module_category_accounting_localizations").unlink()


### PR DESCRIPTION
Reassign the conventional module category for localizations in Odoo 13. The previously assigned categories from Odoo 16 break the Odoo migration process.

 ```
odoo.upgrade.util.exceptions.MigrationError:
Can't rename base.module_category_localization_account_charts to
base.module_category_accounting_localizations_account_charts as it already exists.
```